### PR TITLE
Adding additional Palette Transfer Nodes

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,9 +1,14 @@
-from .color_transfer import PaletteTransferNode, PalleteTransferClustering, ColorPaletteNode
+from .color_transfer import PaletteTransferNode, PalleteTransferClustering, PaletteTransferReinhard, PaletteSoftTransfer, PaletteRbfTransfer, PaletteOptimalTransportTransfer, ColorTransferReinhard, ColorPaletteNode
 
 
 NODE_CLASS_MAPPINGS = {
     "PaletteTransfer": PaletteTransferNode,
     "PalleteTransferClustering": PalleteTransferClustering,
+    "PaletteTransferReinhard": PaletteTransferReinhard,
+    "PalletteSoftTransfer": PaletteSoftTransfer,
+    "PaletteRbfTransfer": PaletteRbfTransfer,
+    "PaletteOptimalTransportTransfer": PaletteOptimalTransportTransfer,
+    "ColorTransferReinhard": ColorTransferReinhard,
     "ColorPalette": ColorPaletteNode,
 }
 NODE_DISPLAY_NAME_MAPPINGS = {

--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,4 @@
-from .color_transfer import PaletteTransferNode, PalleteTransferClustering, PaletteTransferReinhard, PaletteSoftTransfer, PaletteRbfTransfer, PaletteOptimalTransportTransfer, ColorTransferReinhard, ColorPaletteNode
+from .color_transfer import PaletteTransferNode, PalleteTransferClustering, PaletteTransferReinhard, PaletteSoftTransfer, PaletteRbfTransfer, PaletteOptimalTransportTransfer, ReferenceTransferReinhard, ColorPaletteNode
 
 
 NODE_CLASS_MAPPINGS = {
@@ -8,7 +8,7 @@ NODE_CLASS_MAPPINGS = {
     "PalletteSoftTransfer": PaletteSoftTransfer,
     "PaletteRbfTransfer": PaletteRbfTransfer,
     "PaletteOptimalTransportTransfer": PaletteOptimalTransportTransfer,
-    "ColorTransferReinhard": ColorTransferReinhard,
+    "ColorTransferReinhard": ReferenceTransferReinhard,
     "ColorPalette": ColorPaletteNode,
 }
 NODE_DISPLAY_NAME_MAPPINGS = {

--- a/__init__.py
+++ b/__init__.py
@@ -1,11 +1,11 @@
-from .color_transfer import PaletteTransferNode, ColorPaletteNode
+from .color_transfer import PaletteTransferNode, PalleteTransferClustering, ColorPaletteNode
 
 
 NODE_CLASS_MAPPINGS = {
     "PaletteTransfer": PaletteTransferNode,
-    "ColorPalette": ColorPaletteNode,   
+    "PalleteTransferClustering": PalleteTransferClustering,
+    "ColorPalette": ColorPaletteNode,
 }
 NODE_DISPLAY_NAME_MAPPINGS = {
     "PaletteTransfer": "Palette Transfer",
-    "ColorPalette": "Color Palette",
 }

--- a/color_transfer.py
+++ b/color_transfer.py
@@ -1,8 +1,15 @@
+from itertools import combinations
+
 import numpy as np
-from sklearn.cluster import KMeans, MiniBatchKMeans
 import torch
 import ast
 import cv2
+
+from sklearn.cluster import KMeans, MiniBatchKMeans
+from scipy.spatial import Delaunay
+
+from comfy.comfy_types import IO, ComfyNodeABC
+
 from .utils import (
     EuclideanDistance,
     ManhattanDistance,
@@ -13,6 +20,93 @@ from .utils import (
     Blur
 )
 
+class PaletteExtension:
+    @staticmethod
+    def dense_palette(base_palette, points=5, iterations=2):
+        """
+        Interpolate N points between each pair of colors in the base_palette.
+        Do the same for the new colors generated, for a given number of iterations to
+        create a dense mesh of interpolated colors.
+        """
+        # add black and white to the base palette
+        base_palette = set(base_palette)
+        base_palette.add((0,0,0))
+        base_palette.add((255,255,255))
+
+        palette = np.array(list(base_palette), dtype=float)
+
+        for _ in range(iterations):
+            # build all combinations of two distinct indices
+            idx_pairs = list(combinations(range(len(palette)), 2))
+
+            # precompute interpolation fractions
+            t = np.linspace(0, 1, points + 2)[1:-1]
+
+            # for each pair, generate points intermediates
+            new_colors = []
+            for i, j in idx_pairs:
+                c1, c2 = palette[i], palette[j]
+                # broadcast interpolation in one go:
+                inter = c1[None, :] + (c2 - c1)[None, :] * t[:, None]
+                new_colors.append(inter)
+            if new_colors:
+                new_colors = np.vstack(new_colors)
+                palette = np.vstack([palette, new_colors])
+
+            # remove duplicates
+            palette = np.unique(np.rint(palette).astype(int), axis=0).astype(float)
+
+        # final unique, integer RGB list
+        result = [tuple(rgb.astype(int)) for rgb in palette]
+        return result
+
+    @staticmethod
+    def edge_based_palette(base_palette, points=5, iterations=2):
+        """
+        Use Delaunay triangulation to find edges between colors in the base_colors.
+        Do the same for the new colors generated, for a given number of iterations to
+        Create a dense mesh of interpolated colors.
+        In contrast to dense_palette, this method uses the edges of the triangulation
+        to generate new colors, which can lead to a more structured palette.
+        """
+        # add black and white to the base palette
+        base_palette = set(base_palette)
+        base_palette.add((0,0,0))
+        base_palette.add((255,255,255))
+
+        palette = np.array(list(base_palette), dtype=float)
+
+        for _ in range(iterations):
+            # Triangulate current palette to find adjacency edges
+            if len(palette) >= palette.shape[1] + 1:
+                tri = Delaunay(palette)
+                edges = set()
+                for simplex in tri.simplices:
+                    # add all edges of the simplex
+                    for i in range(len(simplex)):
+                        for j in range(i+1, len(simplex)):
+                            a, b = simplex[i], simplex[j]
+                            edges.add(tuple(sorted((a, b))))
+            else:
+                # fallback to all pairs
+                idxs = range(len(palette))
+                edges = set(tuple(sorted((i,j))) for i in idxs for j in idxs if i<j)
+
+            new_colors = []
+            t = np.linspace(0, 1, points+2)[1:-1][:, None]  # shape (points,1)
+
+            for i, j in edges:
+                c1, c2 = palette[i], palette[j]
+                inters = c1 + (c2 - c1) * t  # (points,3)
+                new_colors.append(inters)
+
+            if new_colors:
+                new_stack = np.vstack(new_colors)
+                palette = np.vstack([palette, new_stack])
+                # remove duplicates
+                palette = np.unique(np.rint(palette).astype(int), axis=0).astype(float)
+
+        return [tuple(c.astype(int)) for c in palette]
 
 class ColorSpaceConvert:
     @staticmethod
@@ -20,20 +114,20 @@ class ColorSpaceConvert:
         """Convert image and target colors to specified color space."""
         if color_space == "RGB":
             return image, target_colors
-            
+
         conversion_map = {
             "HSV": (cv2.COLOR_RGB2HSV, cv2.COLOR_HSV2RGB),
             "LAB": (cv2.COLOR_RGB2LAB, cv2.COLOR_LAB2RGB)
         }
-        
+
         forward_conversion, _ = conversion_map[color_space]
-        
+
         converted_image = cv2.cvtColor(image, forward_conversion)
-        
+
         target_colors_array = np.array(target_colors, dtype=np.uint8).reshape(-1, 1, 3)
         converted_colors = cv2.cvtColor(target_colors_array, forward_conversion)
         converted_colors = [tuple(color[0]) for color in converted_colors]
-        
+
         return converted_image, converted_colors
 
     @staticmethod
@@ -41,12 +135,12 @@ class ColorSpaceConvert:
         """Convert image back to RGB color space."""
         if color_space == "RGB":
             return image
-            
+
         conversion_map = {
             "HSV": cv2.COLOR_HSV2RGB,
             "LAB": cv2.COLOR_LAB2RGB
         }
-        
+
         return cv2.cvtColor(image, conversion_map[color_space])
 
 
@@ -63,7 +157,7 @@ class ColorClustering:
         img_array = image.reshape((-1, 3))
         clustering_model = self.method(n_clusters=k, n_init='auto')
         clustering_model.fit(img_array)
-        
+
         return {
             'image': image,
             'main_colors': clustering_model.cluster_centers_.astype(int),
@@ -86,12 +180,12 @@ class ColorMatcher:
     def match_colors(self, detected_colors, target_colors, clustering_model, image_shape):
         """Match detected colors with target colors using the specified distance method."""
         closest_colors = []
-        
+
         for color in detected_colors:
             distances = self.distance_func(color, target_colors)
             closest_color = target_colors[np.argmin(distances)]
             closest_colors.append(closest_color)
-            
+
         closest_colors = np.array(closest_colors)
         return closest_colors[clustering_model.labels_].reshape(image_shape)
 
@@ -103,30 +197,95 @@ class ImagePostProcessor:
     def process_image(self, image):
         """Apply post-processing to the image."""
         processed = np.array(image).astype(np.float32)
-        
+
         if self.gaussian_blur:
             processed = Blur(processed, self.gaussian_blur)
-            
-        return processed / 255.0
-    
 
-class PaletteTransferNode:
+        return processed / 255.0
+
+class PalleteTransferClustering(ComfyNodeABC):
     @classmethod
     def INPUT_TYPES(cls):
         data_in = {
             "required": {
-                "image": ("IMAGE",),
+                "image": (IO.IMAGE,),
                 "target_colors": ("COLOR_LIST",),
-                "color_space": (["RGB", "HSV", "LAB"], {'default': 'RGB'}),
-                "cluster_method": (["Kmeans","Mini batch Kmeans"], {'default': 'Kmeans'}, ),
-                "distance_method": (["Euclidean", "Manhattan", "Cosine Similarity", "HSV Distance", "RGB Weighted Distance", "RGB Weighted Similarity"], {'default': 'Euclidean'}, ),
-                "gaussian_blur": ("INT", {'default': 3, 'min': 0, 'max': 27, 'step': 1}),
+                "palette_extension_method": (["Dense", "Edge", "None"], {'default': 'None'}),
+                "palette_extension_points": (IO.INT, {'min': 2, 'max': 20, 'step': 1, 'default': 5,}),
+                "gaussian_blur": (IO.INT, {'default': 3, 'min': 0, 'max': 27, 'step': 1}),
                 }
             }
         return data_in
 
-    CATEGORY = "Color Transfer"
-    RETURN_TYPES = ("IMAGE",)
+    RETURN_TYPES = (IO.IMAGE,)
+    FUNCTION = "color_transfer"
+    CATEGORY = "Palette Transfer"
+
+    def color_transfer(self, image, target_colors, palette_extension_method, palette_extension_points, gaussian_blur):
+        if len(target_colors) == 0:
+            return (image,)
+
+        processedImages = []
+
+        if palette_extension_method == "Dense":
+            target_colors = PaletteExtension.dense_palette(target_colors, points=palette_extension_points)
+        elif palette_extension_method == "Edge":
+            target_colors = PaletteExtension.edge_based_palette(target_colors, points=palette_extension_points)
+
+
+
+        # Initialize components
+        converter = ColorSpaceConvert()
+        clustering_engine = ColorClustering("Mini batch Kmeans")
+        color_matcher = ColorMatcher("Euclidean")
+        image_processor = ImagePostProcessor(gaussian_blur)
+
+        for img_tensor in image:
+            # Prepare image
+            img = 255. * img_tensor.cpu().numpy()
+
+            # Convert color space
+            converted_img, converted_colors = converter.convert_to_target_space(img, target_colors, "RGB")
+
+            # Perform clustering
+            clustering_result = clustering_engine.cluster_colors(converted_img, len(target_colors))
+
+            # Match colors
+            processed = color_matcher.match_colors(
+                clustering_result['main_colors'],
+                converted_colors,
+                clustering_result['model'],
+                converted_img.shape
+            )
+
+            # Convert back to RGB
+            processed = converter.convert_to_rgb(processed, "RGB")
+
+            # Post-process
+            processed = image_processor.process_image(processed)
+            processed_tensor = torch.from_numpy(processed)[None,]
+
+            processedImages.append(processed_tensor)
+
+        output = torch.cat(processedImages, dim=0)
+        return (output,)
+
+class PaletteTransferNode(ComfyNodeABC):
+    @classmethod
+    def INPUT_TYPES(cls):
+        data_in = {
+            "required": {
+                "image": (IO.IMAGE,),
+                "target_colors": ("COLOR_LIST",),
+                "color_space": (["RGB", "HSV", "LAB"], {'default': 'RGB'}),
+                "cluster_method": (["Kmeans","Mini batch Kmeans"], {'default': 'Kmeans'}, ),
+                "distance_method": (["Euclidean", "Manhattan", "Cosine Similarity", "HSV Distance", "RGB Weighted Distance", "RGB Weighted Similarity"], {'default': 'Euclidean'}, ),
+                "gaussian_blur": (IO.INT, {'default': 3, 'min': 0, 'max': 27, 'step': 1}),
+                }
+            }
+        return data_in
+
+    RETURN_TYPES = (IO.IMAGE,)
     FUNCTION = "color_transfer"
     CATEGORY = "Palette Transfer"
 
@@ -134,9 +293,9 @@ class PaletteTransferNode:
     def color_transfer(self, image, target_colors, color_space, cluster_method, distance_method, gaussian_blur):
         if len(target_colors) == 0:
             return (image,)
-        
+
         processedImages = []
-        
+
         # Initialize components
         converter = ColorSpaceConvert()
         clustering_engine = ColorClustering(cluster_method)
@@ -146,13 +305,13 @@ class PaletteTransferNode:
         for img_tensor in image:
             # Prepare image
             img = 255. * img_tensor.cpu().numpy()
-            
+
             # Convert color space
             converted_img, converted_colors = converter.convert_to_target_space(img, target_colors, color_space)
-            
+
             # Perform clustering
             clustering_result = clustering_engine.cluster_colors(converted_img, len(target_colors))
-            
+
             # Match colors
             processed = color_matcher.match_colors(
                 clustering_result['main_colors'],
@@ -160,33 +319,34 @@ class PaletteTransferNode:
                 clustering_result['model'],
                 converted_img.shape
             )
-            
+
             # Convert back to RGB
             processed = converter.convert_to_rgb(processed, color_space)
-            
+
             # Post-process
             processed = image_processor.process_image(processed)
             processed_tensor = torch.from_numpy(processed)[None,]
-            
+
             processedImages.append(processed_tensor)
-        
+
         output = torch.cat(processedImages, dim=0)
         return (output,)
-    
 
-class ColorPaletteNode:
+
+class ColorPaletteNode(ComfyNodeABC):
     @classmethod
     def INPUT_TYPES(s):
         return {
             "required": {
-                "color_palette": ("STRING", {'default': '[(30, 32, 30), (60, 61, 55), (105, 117, 101), (236, 223, 204)]', 'multiline': True}),
+                "color_palette": (IO.STRING, {'default': '[(30, 32, 30), (60, 61, 55), (105, 117, 101), (236, 223, 204)]', 'multiline': True}),
             },
         }
 
-    CATEGORY = "Color Transfer"
+
     RETURN_TYPES = ("COLOR_LIST", )
     RETURN_NAMES = ("Color palette", )
     FUNCTION = "color_list"
+    CATEGORY = "Palette Transfer"
 
     def color_list(self, color_palette):
         return (ast.literal_eval(color_palette), )

--- a/color_transfer.py
+++ b/color_transfer.py
@@ -348,7 +348,7 @@ class PaletteOptimalTransportTransfer(ComfyNodeABC):
                         "default": 5,
                     },
                 ),
-                "blend_mode": (["original", "grayscale"], {"default": "original"}),
+                "blend_mode": (["Original", "Grayscale"], {"default": "Original"}),
                 "blend_ratio": (
                     IO.FLOAT,
                     {
@@ -422,12 +422,12 @@ class PaletteOptimalTransportTransfer(ComfyNodeABC):
                 transport_plan, axis=1, keepdims=True
             )
 
-            if blend_mode == "original":
+            if blend_mode == "Original":
                 # Blend between original and mapped colors
                 recolored_pixels = (
                     1 - blend_ratio
                 ) * pixels + blend_ratio * mapped_centroids[pixel_labels]
-            elif blend_mode == "grayscale":
+            elif blend_mode == "Grayscale":
                 gray = color.rgb2gray(source)
                 gray_rgb = np.stack([gray] * 3, axis=-1)
                 gray_pixels = gray_rgb.reshape(-1, 3)
@@ -527,7 +527,7 @@ class PaletteSoftTransfer(ComfyNodeABC):
             "required": {
                 "image": (IO.IMAGE,),
                 "target_colors": ("COLOR_LIST",),
-                "blend_mode": (["original", "grayscale"], {"default": "original"}),
+                "blend_mode": (["Original", "Grayscale"], {"default": "Original"}),
                 "blend_ratio": (
                     IO.FLOAT,
                     {
@@ -600,10 +600,10 @@ class PaletteSoftTransfer(ComfyNodeABC):
                 weights.T, palette_lab, axes=(1, 0)
             )  # shape: (N_pixels, 3)
 
-            if blend_mode == "original":
+            if blend_mode == "Original":
                 # Blend between original and projected colors
                 blended = (1 - blend_ratio) * pixels + blend_ratio * projected
-            elif blend_mode == "grayscale":
+            elif blend_mode == "Grayscale":
                 gray = color.rgb2gray(source)  # shape: (H, W)
                 gray_rgb = np.stack([gray] * 3, axis=-1)  # shape: (H, W, 3)
                 # Convert grayscale RGB to Lab (so all blending happens in Lab)

--- a/color_transfer.py
+++ b/color_transfer.py
@@ -252,7 +252,7 @@ def process_image_with_palette(image, target_colors, color_space, cluster_method
 
     return torch.cat(processedImages, dim=0)
 
-class ColorTransferReinhard(ComfyNodeABC):
+class ReferenceTransferReinhard(ComfyNodeABC):
     @classmethod
     def INPUT_TYPES(cls):
         data_in = {
@@ -265,7 +265,7 @@ class ColorTransferReinhard(ComfyNodeABC):
 
     RETURN_TYPES = (IO.IMAGE,)
     FUNCTION = "color_transfer"
-    CATEGORY = "Palette Transfer"
+    CATEGORY = "Color Transfer/Reference Transfer"
 
     def color_transfer(self, image, image_reference):
 
@@ -321,7 +321,7 @@ class PaletteOptimalTransportTransfer(ComfyNodeABC):
 
     RETURN_TYPES = (IO.IMAGE,)
     FUNCTION = "color_transfer"
-    CATEGORY = "Palette Transfer"
+    CATEGORY = "Color Transfer/Palette Transfer"
 
     def color_transfer(self, image, target_colors, palette_extension_method, palette_extension_points, blend_mode, blend_ratio):
 
@@ -394,7 +394,7 @@ class PaletteRbfTransfer(ComfyNodeABC):
 
     RETURN_TYPES = (IO.IMAGE,)
     FUNCTION = "color_transfer"
-    CATEGORY = "Palette Transfer"
+    CATEGORY = "Color Transfer/Palette Transfer"
 
     def color_transfer(self, image, target_colors, rbf_function, epsilon):
         """
@@ -460,7 +460,7 @@ class PaletteSoftTransfer(ComfyNodeABC):
 
     RETURN_TYPES = (IO.IMAGE,)
     FUNCTION = "color_transfer"
-    CATEGORY = "Palette Transfer"
+    CATEGORY = "Color Transfer/Palette Transfer"
 
     def color_transfer(self, image, target_colors, blend_mode, blend_ratio, softness):
         """
@@ -531,7 +531,7 @@ class PaletteTransferReinhard(ComfyNodeABC):
 
     RETURN_TYPES = (IO.IMAGE,)
     FUNCTION = "color_transfer"
-    CATEGORY = "Palette Transfer"
+    CATEGORY = "Color Transfer/Palette Transfer"
 
     def color_transfer(self, image, target_colors):
         if len(target_colors) == 0:
@@ -596,7 +596,7 @@ class PalleteTransferClustering(ComfyNodeABC):
 
     RETURN_TYPES = (IO.IMAGE,)
     FUNCTION = "color_transfer"
-    CATEGORY = "Palette Transfer"
+    CATEGORY = "Color Transfer/Palette Transfer"
 
     def color_transfer(self, image, target_colors, palette_extension_method, palette_extension_points, gaussian_blur):
         if len(target_colors) == 0:
@@ -635,7 +635,7 @@ class PaletteTransferNode(ComfyNodeABC):
 
     RETURN_TYPES = (IO.IMAGE,)
     FUNCTION = "color_transfer"
-    CATEGORY = "Palette Transfer"
+    CATEGORY = "Color Transfer/Palette Transfer"
 
 
     def color_transfer(self, image, target_colors, color_space, cluster_method, distance_method, gaussian_blur):
@@ -667,7 +667,7 @@ class ColorPaletteNode(ComfyNodeABC):
     RETURN_TYPES = ("COLOR_LIST", )
     RETURN_NAMES = ("Color palette", )
     FUNCTION = "color_list"
-    CATEGORY = "Palette Transfer"
+    CATEGORY = "Color Transfer/Palette Transfer"
 
     def color_list(self, color_palette):
         return (ast.literal_eval(color_palette), )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 scikit-learn
 opencv-python
+POT

--- a/workflow_examples/example_workflow_new_nodes.json
+++ b/workflow_examples/example_workflow_new_nodes.json
@@ -1,0 +1,886 @@
+{
+  "id": "59457a40-c7d2-4390-9f07-01ce5d3b80f6",
+  "revision": 0,
+  "last_node_id": 38,
+  "last_link_id": 78,
+  "nodes": [
+    {
+      "id": 26,
+      "type": "LoadImage",
+      "pos": [
+        -42.56291580200195,
+        746.2694702148438
+      ],
+      "size": [
+        274.080078125,
+        314
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            44
+          ]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.32",
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": [
+        "360_F_14894119_v4bqEYTmsztxtIlrHEyaKRuBkbN6oMQZ.webp",
+        "image"
+      ]
+    },
+    {
+      "id": 27,
+      "type": "LoadImage",
+      "pos": [
+        -41.83220291137695,
+        1126.92236328125
+      ],
+      "size": [
+        274.080078125,
+        314
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            47,
+            62
+          ]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.32",
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": [
+        "yellow_icon.png",
+        "image"
+      ]
+    },
+    {
+      "id": 20,
+      "type": "LoadImage",
+      "pos": [
+        -91.65433502197266,
+        336.6929931640625
+      ],
+      "size": [
+        362.4837646484375,
+        352.2925720214844
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            43
+          ]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.32",
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": [
+        "02702-1453193612.png",
+        "image"
+      ]
+    },
+    {
+      "id": 28,
+      "type": "ImageBatch",
+      "pos": [
+        580.4439086914062,
+        745.9865112304688
+      ],
+      "size": [
+        140,
+        46
+      ],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image1",
+          "type": "IMAGE",
+          "link": 48
+        },
+        {
+          "name": "image2",
+          "type": "IMAGE",
+          "link": 47
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            56,
+            59,
+            66,
+            70,
+            72,
+            74
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.32",
+        "Node name for S&R": "ImageBatch"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 15,
+      "type": "PreviewImage",
+      "pos": [
+        1350.9637451171875,
+        172.0648193359375
+      ],
+      "size": [
+        1472.510009765625,
+        317.8247985839844
+      ],
+      "flags": {},
+      "order": 16,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 73
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.32",
+        "Node name for S&R": "PreviewImage"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 35,
+      "type": "PreviewImage",
+      "pos": [
+        1357.0638427734375,
+        -180.43519592285156
+      ],
+      "size": [
+        1472.510009765625,
+        317.8247985839844
+      ],
+      "flags": {},
+      "order": 12,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 75
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.32",
+        "Node name for S&R": "PreviewImage"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 36,
+      "type": "PreviewImage",
+      "pos": [
+        1333.7437744140625,
+        939.0889282226562
+      ],
+      "size": [
+        1472.510009765625,
+        317.8247985839844
+      ],
+      "flags": {},
+      "order": 13,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 76
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.32",
+        "Node name for S&R": "PreviewImage"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 29,
+      "type": "PaletteTransferReinhard",
+      "pos": [
+        936.725830078125,
+        947.5828247070312
+      ],
+      "size": [
+        191.90390014648438,
+        46
+      ],
+      "flags": {},
+      "order": 7,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 59
+        },
+        {
+          "name": "target_colors",
+          "type": "COLOR_LIST",
+          "link": 54
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            76
+          ]
+        }
+      ],
+      "properties": {
+        "aux_id": "stdkoehler/ComfyUI-Color_Transfer",
+        "ver": "68b88335054fca4f82b12d34cde8c6f16283cc41",
+        "Node name for S&R": "PaletteTransferReinhard"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 37,
+      "type": "PreviewImage",
+      "pos": [
+        1341.2269287109375,
+        553.5296020507812
+      ],
+      "size": [
+        1472.510009765625,
+        317.8247985839844
+      ],
+      "flags": {},
+      "order": 14,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 77
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.32",
+        "Node name for S&R": "PreviewImage"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 23,
+      "type": "PalleteTransferClustering",
+      "pos": [
+        915.8627319335938,
+        -39.150146484375
+      ],
+      "size": [
+        304.771484375,
+        126
+      ],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 56
+        },
+        {
+          "name": "target_colors",
+          "type": "COLOR_LIST",
+          "link": 57
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            75
+          ]
+        }
+      ],
+      "properties": {
+        "aux_id": "stdkoehler/ComfyUI-Color_Transfer",
+        "ver": "08dab8b0691d35783216ccf9d5e65ae043dced51",
+        "Node name for S&R": "PalleteTransferClustering"
+      },
+      "widgets_values": [
+        "Dense",
+        5,
+        0
+      ]
+    },
+    {
+      "id": 33,
+      "type": "PaletteRbfTransfer",
+      "pos": [
+        920.2803955078125,
+        1332.6422119140625
+      ],
+      "size": [
+        270,
+        102
+      ],
+      "flags": {},
+      "order": 9,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 70
+        },
+        {
+          "name": "target_colors",
+          "type": "COLOR_LIST",
+          "link": 68
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            78
+          ]
+        }
+      ],
+      "properties": {
+        "aux_id": "stdkoehler/ComfyUI-Color_Transfer",
+        "ver": "68b88335054fca4f82b12d34cde8c6f16283cc41",
+        "Node name for S&R": "PaletteRbfTransfer"
+      },
+      "widgets_values": [
+        "gaussian",
+        0.7000000000000001
+      ]
+    },
+    {
+      "id": 38,
+      "type": "PreviewImage",
+      "pos": [
+        1337.157470703125,
+        1334.32080078125
+      ],
+      "size": [
+        1472.510009765625,
+        317.8247985839844
+      ],
+      "flags": {},
+      "order": 15,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 78
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.32",
+        "Node name for S&R": "PreviewImage"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 31,
+      "type": "ColorTransferReinhard",
+      "pos": [
+        978.1552734375,
+        1694.1551513671875
+      ],
+      "size": [
+        181.77304077148438,
+        46
+      ],
+      "flags": {},
+      "order": 11,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 74
+        },
+        {
+          "name": "image_reference",
+          "type": "IMAGE",
+          "link": 62
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            61
+          ]
+        }
+      ],
+      "properties": {
+        "aux_id": "stdkoehler/ComfyUI-Color_Transfer",
+        "ver": "68b88335054fca4f82b12d34cde8c6f16283cc41",
+        "Node name for S&R": "ColorTransferReinhard"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 30,
+      "type": "PreviewImage",
+      "pos": [
+        1354.0823974609375,
+        1717.6182861328125
+      ],
+      "size": [
+        1460.6881103515625,
+        326.49432373046875
+      ],
+      "flags": {},
+      "order": 17,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 61
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.32",
+        "Node name for S&R": "PreviewImage"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 25,
+      "type": "ImageBatch",
+      "pos": [
+        336.3641357421875,
+        619.2080688476562
+      ],
+      "size": [
+        140,
+        46
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image1",
+          "type": "IMAGE",
+          "link": 43
+        },
+        {
+          "name": "image2",
+          "type": "IMAGE",
+          "link": 44
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            48
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.32",
+        "Node name for S&R": "ImageBatch"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 12,
+      "type": "ColorPalette",
+      "pos": [
+        -45.319950103759766,
+        -34.96229553222656
+      ],
+      "size": [
+        400,
+        200
+      ],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "Color palette",
+          "type": "COLOR_LIST",
+          "links": [
+            54,
+            57,
+            65,
+            68,
+            71
+          ]
+        }
+      ],
+      "properties": {
+        "aux_id": "stdkoehler/ComfyUI-Color_Transfer",
+        "ver": "08dab8b0691d35783216ccf9d5e65ae043dced51",
+        "Node name for S&R": "ColorPalette",
+        "cnr_id": "ComfyUI-Color_Transfer"
+      },
+      "widgets_values": [
+        "[\n  (255, 0, 0),\n  (103, 58, 183),\n]"
+      ]
+    },
+    {
+      "id": 32,
+      "type": "PalletteSoftTransfer",
+      "pos": [
+        980.4177856445312,
+        558.8236083984375
+      ],
+      "size": [
+        270,
+        126
+      ],
+      "flags": {},
+      "order": 8,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 66
+        },
+        {
+          "name": "target_colors",
+          "type": "COLOR_LIST",
+          "link": 65
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            77
+          ]
+        }
+      ],
+      "properties": {
+        "aux_id": "stdkoehler/ComfyUI-Color_Transfer",
+        "ver": "68b88335054fca4f82b12d34cde8c6f16283cc41",
+        "Node name for S&R": "PalletteSoftTransfer"
+      },
+      "widgets_values": [
+        "Grayscale",
+        0.4,
+        1
+      ]
+    },
+    {
+      "id": 34,
+      "type": "PaletteOptimalTransportTransfer",
+      "pos": [
+        910.7619018554688,
+        171.1381378173828
+      ],
+      "size": [
+        316.4439697265625,
+        150
+      ],
+      "flags": {},
+      "order": 10,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 72
+        },
+        {
+          "name": "target_colors",
+          "type": "COLOR_LIST",
+          "link": 71
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            73
+          ]
+        }
+      ],
+      "properties": {
+        "aux_id": "stdkoehler/ComfyUI-Color_Transfer",
+        "ver": "68b88335054fca4f82b12d34cde8c6f16283cc41",
+        "Node name for S&R": "PaletteOptimalTransportTransfer"
+      },
+      "widgets_values": [
+        "Dense",
+        5,
+        "Grayscale",
+        0.5
+      ]
+    }
+  ],
+  "links": [
+    [
+      43,
+      20,
+      0,
+      25,
+      0,
+      "IMAGE"
+    ],
+    [
+      44,
+      26,
+      0,
+      25,
+      1,
+      "IMAGE"
+    ],
+    [
+      47,
+      27,
+      0,
+      28,
+      1,
+      "IMAGE"
+    ],
+    [
+      48,
+      25,
+      0,
+      28,
+      0,
+      "IMAGE"
+    ],
+    [
+      54,
+      12,
+      0,
+      29,
+      1,
+      "COLOR_LIST"
+    ],
+    [
+      56,
+      28,
+      0,
+      23,
+      0,
+      "IMAGE"
+    ],
+    [
+      57,
+      12,
+      0,
+      23,
+      1,
+      "COLOR_LIST"
+    ],
+    [
+      59,
+      28,
+      0,
+      29,
+      0,
+      "IMAGE"
+    ],
+    [
+      61,
+      31,
+      0,
+      30,
+      0,
+      "IMAGE"
+    ],
+    [
+      62,
+      27,
+      0,
+      31,
+      1,
+      "IMAGE"
+    ],
+    [
+      65,
+      12,
+      0,
+      32,
+      1,
+      "COLOR_LIST"
+    ],
+    [
+      66,
+      28,
+      0,
+      32,
+      0,
+      "IMAGE"
+    ],
+    [
+      68,
+      12,
+      0,
+      33,
+      1,
+      "COLOR_LIST"
+    ],
+    [
+      70,
+      28,
+      0,
+      33,
+      0,
+      "IMAGE"
+    ],
+    [
+      71,
+      12,
+      0,
+      34,
+      1,
+      "COLOR_LIST"
+    ],
+    [
+      72,
+      28,
+      0,
+      34,
+      0,
+      "IMAGE"
+    ],
+    [
+      73,
+      34,
+      0,
+      15,
+      0,
+      "IMAGE"
+    ],
+    [
+      74,
+      28,
+      0,
+      31,
+      0,
+      "IMAGE"
+    ],
+    [
+      75,
+      23,
+      0,
+      35,
+      0,
+      "IMAGE"
+    ],
+    [
+      76,
+      29,
+      0,
+      36,
+      0,
+      "IMAGE"
+    ],
+    [
+      77,
+      32,
+      0,
+      37,
+      0,
+      "IMAGE"
+    ],
+    [
+      78,
+      33,
+      0,
+      38,
+      0,
+      "IMAGE"
+    ]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 0.7513148009015777,
+      "offset": [
+        2464.874353627938,
+        249.70144758588646
+      ]
+    },
+    "frontendVersion": "1.18.9"
+  },
+  "version": 0.4
+}


### PR DESCRIPTION
Love your idea with the clustering. As you mentioned there is some problem with posterization that you fix by using img2img.
In my use-case I only had 2 colors in the palette which made this very difficult.

I introduced an additional node that uses your original clustering but creates an interpolated color palette from the given palette which leads to better results.

Then I fell into the rabbit hole and introduced a series of other Color Transfer nodes

![image](https://github.com/user-attachments/assets/bf283efe-5341-4c9b-8a86-5e943f4f3517)

I also adapted the naming so that we are now under Color Transfer in the Node library

![image](https://github.com/user-attachments/assets/0a7a5e48-81fb-4b95-895d-4f4e44f8fe82)

